### PR TITLE
Update aws.yml to stop using actions/upload-artifact & actions/downlo…

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -26,7 +26,7 @@ jobs:
       run: make chromium.zip
 
     - name: Upload Layer Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: chromium
         path: chromium.zip
@@ -56,7 +56,7 @@ jobs:
       uses: aws-actions/setup-sam@v2
 
     - name: Download Layer Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: chromium
 


### PR DESCRIPTION
…ad-artifact v3

These v3 actions are deprecated and about to stop running.